### PR TITLE
feat: add static ppt avatar video skill

### DIFF
--- a/ppt-avatar-video/SKILL.md
+++ b/ppt-avatar-video/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: ppt-avatar-video
+description: Convert a PPT, PPTX, or PDF directly into a presenter video by preserving each page as a static full-frame slide and overlaying one transparent talking avatar. Use for fast deck-to-video requests without bespoke motion design; do not use for cinematic intros, slide redesign, or tutorial screen recordings.
+---
+
+# PPT Avatar Video
+
+Produce the final video quickly. This is a conversion workflow, not a motion-design workflow.
+
+## Scope boundary
+
+- Preserve every source page as a static full-frame image in the original order.
+- Place one transparent talking avatar above the slides for the whole program.
+- Use hard cuts between pages by default. Add only a short dissolve when the user explicitly requests it.
+- Do not select a design preset, construct an arc, search the HyperFrames catalog, choose blueprints or rules, redesign slides, or author per-slide animation.
+- Do not invoke a general intro-video or motion-graphics workflow unless the user explicitly asks for custom motion.
+- Default to direct final delivery. Pause for preview approval only when the user asks to review first.
+
+## Preserve the requested configuration
+
+Use supplied source, aspect ratio, avatar ID, voice ID, presenter anchor, and presenter scale exactly. Do not list or search avatars or voices when IDs are already supplied. Map 16:9 to `landscape`, 9:16 to `portrait`, and 1:1 to `square` for avatar generation. Transparent JoggAI output requires `--screen-style 3 --no-caption`.
+
+If the user does not specify placement, use bottom-right. If scale is absent, use a visible presenter width of 14% of the frame. Scale refers to the non-transparent avatar bounds, not the full video canvas. Align the visible avatar's bottom edge with the frame bottom on every page.
+
+If an exact supplied avatar or voice is rejected, report that blocker. Never silently substitute another identity or voice.
+
+## Fast path
+
+### 1. Rasterize the deck once
+
+For a web-chat upload, download it with `okou web download-file`. Render ordered pages with:
+
+```bash
+okou presentation screenshot --input SOURCE --out PROJECT/assets/slides --width WIDTH --height HEIGHT --json
+```
+
+Use the requested final frame size, normally 1920x1080. Do not separately convert PPT to PPTX unless text or speaker-note extraction genuinely requires it. Never recreate or restyle a source page.
+
+### 2. Write one narration unit per page
+
+Prefer, in order: user script, speaker notes, visible slide text, then a concise literal description of the page. Keep one sentence or short paragraph per page and preserve page order. Do not invent a marketing story arc merely because the deck is sparse.
+
+Join the page units into one script and retain the page-to-unit mapping. As soon as the script is stable, start one talking-avatar generation job. Do not generate standalone TTS: the avatar-video result already contains the requested voice audio.
+
+Before generation, run the current type help once, then use the supplied IDs directly. Put long or quote-sensitive narration in a file and pipe it through standard input:
+
+```bash
+okou generate avatar-video --provider built-in \
+  --avatar-id AVATAR_ID \
+  --voice-id VOICE_ID \
+  --aspect-ratio AVATAR_RATIO \
+  --screen-style 3 \
+  --no-caption \
+  --video-name VIDEO_NAME \
+  --json < PROJECT/narration.txt
+```
+
+While that provider job runs, stage the slide assets and prepare the composition manifest. Run these independent branches concurrently when the execution surface permits it.
+
+### 3. Recover page timings
+
+Download the returned transparent WebM as `assets/presenter.webm` and probe its exact duration. Transcribe it once with `okou video transcribe --file PROJECT/assets/presenter.webm` and align each narration unit to its page. Put a cut at the start of the next unit, or at the midpoint of a real silence gap between units. The first page starts at zero and the final page extends through the exact media duration.
+
+If transcription is unavailable, distribute the measured duration in proportion to spoken word counts, then assign rounding residue to the last page. Do not use the provider's rounded duration when `ffprobe` is available.
+
+### 4. Measure alpha bounds without re-encoding
+
+Resolve this skill's mounted directory from the path shown in the available-skills list, then run:
+
+```bash
+node SKILL_DIR/scripts/probe-alpha-bbox.mjs PROJECT/assets/presenter.webm
+```
+
+Copy its `sourceWidth`, `sourceHeight`, and `bbox` values into the manifest. The composition builder uses CSS clipping and positioning so the visible cutout has the requested width and bottom alignment. Do not crop or transcode the VP9 WebM locally.
+
+Stage only the final presenter WebM and slide images. Do not keep an uncropped duplicate or an unused still inside the cloud-render project.
+
+### 5. Build the static composition
+
+Create `composition-input.json` in the project using this schema:
+
+```json
+{
+  "id": "deck-video",
+  "width": 1920,
+  "height": 1080,
+  "fps": 30,
+  "background": "#000000",
+  "hyperframesVersion": "0.8.26",
+  "slides": [
+    { "path": "assets/slides/page-001.png", "duration": 4.2 },
+    { "path": "assets/slides/page-002.png", "duration": 5.1 }
+  ],
+  "presenter": {
+    "path": "assets/presenter.webm",
+    "sourceWidth": 1920,
+    "sourceHeight": 1080,
+    "bbox": { "x": 618, "y": 184, "width": 596, "height": 874 },
+    "visibleWidthFraction": 0.14,
+    "anchor": "bottom-right"
+  }
+}
+```
+
+Use the project-pinned HyperFrames version rather than updating during a job. Then run:
+
+```bash
+node SKILL_DIR/scripts/build-project.mjs --manifest PROJECT/composition-input.json --out PROJECT
+```
+
+The builder creates one `data-no-timeline` root composition with static image clips, one persistent transparent video clip, and one audio clip. That marker is the HyperFrames contract for an intentionally static composition; do not add a fake GSAP tween merely to make geometry change. Do not replace the composition with individually authored slide HTML files.
+
+### 6. Run one pre-render gate
+
+After inputs and timing are final, run one `lint`, one strict `check`, and a small snapshot set covering the first, middle, and last pages. Fix failures and rerun only the affected fast check; run the full strict check once more only if composition structure or timing changed.
+
+```bash
+npx --yes hyperframes@0.8.26 lint PROJECT --json
+npx --yes hyperframes@0.8.26 check PROJECT --strict --samples 5 --json
+npx --yes hyperframes@0.8.26 snapshot PROJECT --at FIRST,MIDDLE,LAST --no-end --describe false
+```
+
+Do not run text-layout or contrast audits against bitmap slide contents. Those pixels belong to the source presentation and contain no authored DOM text. Verify instead:
+
+- page count and order;
+- no stretching or unintended cropping;
+- transparent avatar decoding;
+- requested visible width and anchor;
+- captions absent;
+- final slide timing equals presenter duration.
+
+### 7. Render in the cloud once
+
+Cloud is the default final renderer. If `HYPERFRAMES_API_KEY` and `HEYGEN_API_KEY` are absent but `HEYGEN_TOKEN` is present, pass it to the command as `HEYGEN_API_KEY="$HEYGEN_TOKEN"` without printing the token.
+
+Run a dry-run size check, then one idempotent render using the same key for any safe retry:
+
+```bash
+npx --yes hyperframes@0.8.26 cloud render PROJECT --dry-run --json
+
+HEYGEN_API_KEY="$HEYGEN_TOKEN" npx --yes hyperframes@0.8.26 cloud render PROJECT \
+  --fps FPS --quality high --format mp4 --resolution 1080p \
+  --aspect-ratio ASPECT --wait --output PROJECT/renders/final.mp4 \
+  --idempotency-key IDEMPOTENCY_KEY --json
+```
+
+Use local final rendering only when the user explicitly requests it or cloud access is unavailable. Do not render a full local copy merely as a cloud comparison.
+
+### 8. Final verification and delivery
+
+Run `ffprobe`, a full `ffmpeg` decode, and final ASR comparison concurrently where possible. Confirm resolution, fps, frame count, video duration, audio duration, page order, narration completeness, and presenter placement. For web chat, deliver the verified file with `okou web upload-file -f PROJECT/renders/final.mp4`.
+
+Report a compact timing table with: deck download, page rasterization, narration preparation, avatar generation, alpha-bound probe, composition build, pre-render QA, cloud package/upload, queue/render, download, final QA, and delivery. Distinguish provider time from agent/tool overhead.
+
+## Retry and cost rules
+
+- Use an idempotency key for every cloud render.
+- Retry one transient provider or cloud failure at most once. Do not submit a second billed generation when the first job may still be running.
+- A request to create the final video authorizes the normal avatar-generation and cloud-render charges. Any materially different regeneration needs fresh user direction.

--- a/ppt-avatar-video/scripts/build-project.mjs
+++ b/ppt-avatar-video/scripts/build-project.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+function fail(message) {
+  process.stderr.write(`build-project: ${message}\n`);
+  process.exit(1);
+}
+
+function parseFlag(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function finiteNumber(value, label, { min = -Infinity, max = Infinity } = {}) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < min || number > max) {
+    fail(`${label} must be a finite number between ${min} and ${max}`);
+  }
+  return number;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function formatSeconds(value) {
+  return Number(value.toFixed(6)).toString();
+}
+
+const manifestArg = parseFlag("--manifest");
+const outArg = parseFlag("--out");
+if (!manifestArg || !outArg) {
+  fail(
+    "usage: build-project.mjs --manifest composition-input.json --out PROJECT_DIR",
+  );
+}
+
+const manifestPath = path.resolve(manifestArg);
+const outDir = path.resolve(outArg);
+if (!existsSync(manifestPath)) fail(`manifest not found: ${manifestArg}`);
+
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+} catch (error) {
+  fail(`invalid manifest JSON: ${error.message}`);
+}
+
+const id = String(manifest.id || "deck-video");
+if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(id)) {
+  fail("id must be a lowercase kebab-case identifier of at most 63 characters");
+}
+
+const width = finiteNumber(manifest.width ?? 1920, "width", {
+  min: 16,
+  max: 7680,
+});
+const height = finiteNumber(manifest.height ?? 1080, "height", {
+  min: 16,
+  max: 7680,
+});
+const fps = finiteNumber(manifest.fps ?? 30, "fps", { min: 1, max: 240 });
+const background = String(manifest.background || "#000000");
+const hyperframesVersion = String(manifest.hyperframesVersion || "0.8.26");
+
+if (!Array.isArray(manifest.slides) || manifest.slides.length === 0) {
+  fail("slides must be a non-empty array");
+}
+
+mkdirSync(outDir, { recursive: true });
+const outPrefix = `${outDir}${path.sep}`;
+
+function validateAsset(relativePath, label) {
+  if (
+    typeof relativePath !== "string" ||
+    !relativePath ||
+    path.isAbsolute(relativePath)
+  ) {
+    fail(`${label} must be a project-relative path`);
+  }
+  const absolute = path.resolve(outDir, relativePath);
+  if (!absolute.startsWith(outPrefix) || !existsSync(absolute)) {
+    fail(`${label} is missing or outside the project: ${relativePath}`);
+  }
+  return relativePath.split(path.sep).join("/");
+}
+
+const slides = manifest.slides.map((slide, index) => ({
+  path: validateAsset(slide.path, `slides[${index}].path`),
+  duration: finiteNumber(slide.duration, `slides[${index}].duration`, {
+    min: 0.1,
+    max: 3600,
+  }),
+}));
+
+const presenter = manifest.presenter;
+if (!presenter || typeof presenter !== "object") fail("presenter is required");
+
+const presenterPath = validateAsset(presenter.path, "presenter.path");
+const audioPath = validateAsset(
+  presenter.audioPath || presenter.path,
+  "presenter.audioPath",
+);
+const sourceWidth = finiteNumber(
+  presenter.sourceWidth,
+  "presenter.sourceWidth",
+  { min: 1 },
+);
+const sourceHeight = finiteNumber(
+  presenter.sourceHeight,
+  "presenter.sourceHeight",
+  { min: 1 },
+);
+const bbox = presenter.bbox || {};
+const bboxX = finiteNumber(bbox.x, "presenter.bbox.x", { min: 0 });
+const bboxY = finiteNumber(bbox.y, "presenter.bbox.y", { min: 0 });
+const bboxWidth = finiteNumber(bbox.width, "presenter.bbox.width", { min: 1 });
+const bboxHeight = finiteNumber(bbox.height, "presenter.bbox.height", {
+  min: 1,
+});
+if (bboxX + bboxWidth > sourceWidth || bboxY + bboxHeight > sourceHeight) {
+  fail("presenter.bbox exceeds the source video dimensions");
+}
+
+const visibleWidthFraction = finiteNumber(
+  presenter.visibleWidthFraction ?? 0.14,
+  "presenter.visibleWidthFraction",
+  { min: 0.01, max: 1 },
+);
+const anchor = String(presenter.anchor || "bottom-right");
+if (!new Set(["bottom-right", "bottom-left"]).has(anchor)) {
+  fail("presenter.anchor must be bottom-right or bottom-left");
+}
+
+const totalDuration = slides.reduce((sum, slide) => sum + slide.duration, 0);
+const targetVisibleWidth = width * visibleWidthFraction;
+const scale = targetVisibleWidth / bboxWidth;
+const renderedWidth = sourceWidth * scale;
+const renderedHeight = sourceHeight * scale;
+const bottomOffset = -(sourceHeight - bboxY - bboxHeight) * scale;
+const horizontalRule =
+  anchor === "bottom-right"
+    ? `right: ${formatSeconds(-(sourceWidth - bboxX - bboxWidth) * scale)}px;`
+    : `left: ${formatSeconds(-bboxX * scale)}px;`;
+const clipTop = (bboxY / sourceHeight) * 100;
+const clipRight = ((sourceWidth - bboxX - bboxWidth) / sourceWidth) * 100;
+const clipBottom = ((sourceHeight - bboxY - bboxHeight) / sourceHeight) * 100;
+const clipLeft = (bboxX / sourceWidth) * 100;
+
+let cursor = 0;
+const slideTags = slides
+  .map((slide, index) => {
+    const start = cursor;
+    cursor += slide.duration;
+    return `      <img id="slide-${String(index + 1).padStart(3, "0")}" class="clip slide" src="${escapeHtml(slide.path)}" alt="Slide ${index + 1}" data-start="${formatSeconds(start)}" data-duration="${formatSeconds(slide.duration)}" />`;
+  })
+  .join("\n");
+
+const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=${width}, height=${height}" />
+    <title>${escapeHtml(id)}</title>
+    <style>
+      * { box-sizing: border-box; }
+      html, body { margin: 0; width: ${width}px; height: ${height}px; overflow: hidden; background: ${escapeHtml(background)}; }
+      #root { position: relative; width: ${width}px; height: ${height}px; overflow: hidden; isolation: isolate; background: ${escapeHtml(background)}; }
+      .clip { position: absolute; }
+      .slide { inset: 0; z-index: 1; width: ${width}px; height: ${height}px; object-fit: contain; background: ${escapeHtml(background)}; }
+      .presenter-video {
+        z-index: 20;
+        ${horizontalRule}
+        bottom: ${formatSeconds(bottomOffset)}px;
+        width: ${formatSeconds(renderedWidth)}px;
+        height: ${formatSeconds(renderedHeight)}px;
+        clip-path: inset(${formatSeconds(clipTop)}% ${formatSeconds(clipRight)}% ${formatSeconds(clipBottom)}% ${formatSeconds(clipLeft)}%);
+        pointer-events: none;
+      }
+      .presenter-audio { width: 0; height: 0; }
+    </style>
+  </head>
+  <body>
+    <div id="root" data-composition-id="main" data-no-timeline data-start="0" data-duration="${formatSeconds(totalDuration)}" data-width="${width}" data-height="${height}">
+${slideTags}
+      <video id="presenter-video" class="clip presenter-video" src="${escapeHtml(presenterPath)}" data-start="0" data-duration="${formatSeconds(totalDuration)}" data-track-index="20" data-layout-allow-overlap data-layout-allow-overflow muted playsinline preload="auto" aria-label="Presenter"></video>
+      <audio id="presenter-audio" class="clip presenter-audio" src="${escapeHtml(audioPath)}" data-start="0" data-duration="${formatSeconds(totalDuration)}" data-track-index="30" data-volume="1" preload="auto"></audio>
+    </div>
+  </body>
+</html>
+`;
+
+const packageJson = {
+  name: id,
+  private: true,
+  type: "module",
+  scripts: {
+    dev: `npx --yes hyperframes@${hyperframesVersion} preview`,
+    check: `npx --yes hyperframes@${hyperframesVersion} check`,
+    render: `npx --yes hyperframes@${hyperframesVersion} render`,
+    publish: `npx --yes hyperframes@${hyperframesVersion} publish`,
+  },
+};
+
+const hyperframesJson = {
+  $schema: "https://hyperframes.heygen.com/schema/hyperframes.json",
+  paths: {
+    blocks: "compositions",
+    components: "compositions/components",
+    assets: "assets",
+  },
+  media: { autoProxy: true },
+  authoringSkill: "ppt-avatar-video",
+  registryItems: [],
+};
+
+writeFileSync(path.join(outDir, "index.html"), html);
+writeFileSync(
+  path.join(outDir, "index.motion.json"),
+  `${JSON.stringify(
+    {
+      duration: totalDuration,
+      assertions: [{ kind: "appearsBy", selector: "#slide-001", bySec: 0.1 }],
+    },
+    null,
+    2,
+  )}\n`,
+);
+writeFileSync(
+  path.join(outDir, "package.json"),
+  `${JSON.stringify(packageJson, null, 2)}\n`,
+);
+writeFileSync(
+  path.join(outDir, "hyperframes.json"),
+  `${JSON.stringify(hyperframesJson, null, 2)}\n`,
+);
+writeFileSync(
+  path.join(outDir, "meta.json"),
+  `${JSON.stringify({ id, name: id, createdAt: new Date().toISOString() }, null, 2)}\n`,
+);
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      project: outDir,
+      slides: slides.length,
+      duration: totalDuration,
+      fps,
+      presenter: {
+        anchor,
+        visibleWidthFraction,
+        targetVisibleWidth,
+        scale,
+        renderedWidth,
+        renderedHeight,
+      },
+    },
+    null,
+    2,
+  )}\n`,
+);

--- a/ppt-avatar-video/scripts/probe-alpha-bbox.mjs
+++ b/ppt-avatar-video/scripts/probe-alpha-bbox.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+function fail(message) {
+  process.stderr.write(`probe-alpha-bbox: ${message}\n`);
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const videoArg = args.find((arg) => !arg.startsWith("--"));
+const limitArg = args.find((arg) => arg.startsWith("--limit="));
+const limit = limitArg ? Number(limitArg.slice("--limit=".length)) : 0.01;
+
+if (!videoArg) fail("usage: probe-alpha-bbox.mjs VIDEO [--limit=0.01]");
+if (!Number.isFinite(limit) || limit < 0 || limit > 1)
+  fail("--limit must be between 0 and 1");
+
+const video = path.resolve(videoArg);
+if (!existsSync(video)) fail(`video not found: ${videoArg}`);
+
+const probe = spawnSync(
+  "ffprobe",
+  [
+    "-v",
+    "error",
+    "-select_streams",
+    "v:0",
+    "-show_entries",
+    "stream=codec_name,width,height:stream_tags=ALPHA_MODE",
+    "-of",
+    "json",
+    video,
+  ],
+  { encoding: "utf8" },
+);
+
+if (probe.error) fail(`unable to run ffprobe: ${probe.error.message}`);
+if (probe.status !== 0) fail(probe.stderr.trim() || "ffprobe failed");
+
+let stream;
+try {
+  stream = JSON.parse(probe.stdout).streams?.[0];
+} catch {
+  fail("ffprobe returned invalid JSON");
+}
+
+if (!stream?.width || !stream?.height) fail("video dimensions were not found");
+
+const ffmpegArgs = ["-hide_banner", "-loglevel", "info"];
+if (stream.codec_name === "vp9") ffmpegArgs.push("-c:v", "libvpx-vp9");
+ffmpegArgs.push(
+  "-i",
+  video,
+  "-vf",
+  `alphaextract,cropdetect=limit=${limit}:round=2:reset=0`,
+  "-an",
+  "-f",
+  "null",
+  "-",
+);
+
+const scan = spawnSync("ffmpeg", ffmpegArgs, {
+  encoding: "utf8",
+  maxBuffer: 32 * 1024 * 1024,
+});
+
+if (scan.error) fail(`unable to run ffmpeg: ${scan.error.message}`);
+if (scan.status !== 0)
+  fail(scan.stderr.trim().split("\n").slice(-8).join("\n") || "ffmpeg failed");
+
+const crops = [...scan.stderr.matchAll(/crop=(\d+):(\d+):(\d+):(\d+)/g)];
+if (crops.length === 0) {
+  fail(
+    "no alpha bounds detected; confirm that the video has a decodable alpha channel",
+  );
+}
+
+const [, width, height, x, y] = crops.at(-1);
+const result = {
+  sourceWidth: Number(stream.width),
+  sourceHeight: Number(stream.height),
+  bbox: {
+    x: Number(x),
+    y: Number(y),
+    width: Number(width),
+    height: Number(height),
+  },
+  codec: stream.codec_name,
+  alphaMode: stream.tags?.ALPHA_MODE ?? null,
+  scannedFrames: crops.length,
+};
+
+if (
+  result.bbox.x < 0 ||
+  result.bbox.y < 0 ||
+  result.bbox.width <= 0 ||
+  result.bbox.height <= 0 ||
+  result.bbox.x + result.bbox.width > result.sourceWidth ||
+  result.bbox.y + result.bbox.height > result.sourceHeight
+) {
+  fail(`detected invalid bounds: ${JSON.stringify(result)}`);
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);


### PR DESCRIPTION
## Summary

- add a focused `ppt-avatar-video` skill for direct static-deck presenter videos
- preserve each source page as a full-frame image and use one persistent transparent talking avatar
- add deterministic helpers for alpha-bound measurement and HyperFrames project generation
- default final output to a single idempotent cloud render with stage timing

## Validation

- `quick_validate.py ppt-avatar-video`
- `prettier --check` for the skill and both helper scripts
- `node --check` for both helper scripts
- real 5-slide composition smoke test with a 1920x1080 VP9 alpha presenter
- HyperFrames 0.8.26 strict check: 0 errors, 0 warnings across lint, runtime, layout, motion, and contrast
- alpha-bound probe result: 596x874 at (618,184), matching the expected Harper cutout
