### PR TITLE
fix: support voice-only ppt videos

### DIFF
--- a/ppt-avatar-video/SKILL.md
+++ b/ppt-avatar-video/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: ppt-avatar-video
-description: Convert a PPT, PPTX, or PDF directly into a presenter video by preserving each page as a static full-frame slide and overlaying one transparent talking avatar. Use for fast deck-to-video requests without bespoke motion design; do not use for cinematic intros, slide redesign, or tutorial screen recordings.
+description: Convert a PPT, PPTX, or PDF directly into a narrated video by preserving each page as a static full-frame slide, with an optional transparent talking avatar. Use for fast deck-to-video requests with voice only or avatar plus voice; do not use for cinematic intros, slide redesign, or tutorial screen recordings.
 ---
 
-# PPT Avatar Video
+# PPT Narrated Video
 
 Produce the final video quickly. This is a conversion workflow, not a motion-design workflow.
 
 ## Scope boundary
 
 - Preserve every source page as a static full-frame image in the original order.
-- Place one transparent talking avatar above the slides for the whole program.
+- Always include the selected narration. Overlay a transparent talking avatar only when the user selected one.
 - Use hard cuts between pages by default. Add only a short dissolve when the user explicitly requests it.
 - Do not select a design preset, construct an arc, search the HyperFrames catalog, choose blueprints or rules, redesign slides, or author per-slide animation.
 - Do not invoke a general intro-video or motion-graphics workflow unless the user explicitly asks for custom motion.
@@ -18,11 +18,20 @@ Produce the final video quickly. This is a conversion workflow, not a motion-des
 
 ## Preserve the requested configuration
 
-Use supplied source, aspect ratio, avatar ID, voice ID, presenter anchor, and presenter scale exactly. Do not list or search avatars or voices when IDs are already supplied. Map 16:9 to `landscape`, 9:16 to `portrait`, and 1:1 to `square` for avatar generation. Transparent JoggAI output requires `--screen-style 3 --no-caption`.
+Use the supplied source, aspect ratio, and voice exactly. Treat avatar configuration as optional: never add or choose an avatar when the user supplied only a voice. When an avatar is supplied, preserve its ID, presenter anchor, and presenter scale exactly. Do not list or search avatars or voices when compatible identifiers are already supplied.
 
-If the user does not specify placement, use bottom-right. If scale is absent, use a visible presenter width of 14% of the frame. Scale refers to the non-transparent avatar bounds, not the full video canvas. Align the visible avatar's bottom edge with the frame bottom on every page.
+For avatar mode, map 16:9 to `landscape`, 9:16 to `portrait`, and 1:1 to `square`. Transparent JoggAI output requires `--screen-style 3 --no-caption`. If placement is absent, use bottom-right. If scale is absent, use a visible presenter width of 14% of the frame. Scale refers to the non-transparent avatar bounds, not the full video canvas. Align the visible avatar's bottom edge with the frame bottom on every page.
 
 If an exact supplied avatar or voice is rejected, report that blocker. Never silently substitute another identity or voice.
+
+## Select the media mode
+
+Choose one mode before starting a billed generation:
+
+- **Avatar mode:** an avatar is explicitly supplied. Generate one transparent talking-avatar WebM. Its audio is also the narration track; do not generate standalone TTS.
+- **Voice-only mode:** no avatar is supplied and a voice is supplied. Generate one narration audio file. Do not select a default avatar, create a hidden avatar, download an avatar cutout, or run the alpha-bound probe.
+
+Run the relevant generation type's current help before generation. A provider-specific voice ID is not interchangeable with another provider's voice name. In particular, do not pass a JoggAI `voice-id` to `okou generate voice --voice`. Use a voice-only provider only when it accepts the exact selected voice; otherwise report the unsupported voice-only configuration instead of substituting.
 
 ## Fast path
 
@@ -40,9 +49,11 @@ Use the requested final frame size, normally 1920x1080. Do not separately conver
 
 Prefer, in order: user script, speaker notes, visible slide text, then a concise literal description of the page. Keep one sentence or short paragraph per page and preserve page order. Do not invent a marketing story arc merely because the deck is sparse.
 
-Join the page units into one script and retain the page-to-unit mapping. As soon as the script is stable, start one talking-avatar generation job. Do not generate standalone TTS: the avatar-video result already contains the requested voice audio.
+Join the page units into one script and retain the page-to-unit mapping. As soon as the script is stable, start exactly one generation job for the selected media mode.
 
-Before generation, run the current type help once, then use the supplied IDs directly. Put long or quote-sensitive narration in a file and pipe it through standard input:
+Put long or quote-sensitive narration in a file and pipe it through standard input.
+
+Avatar mode:
 
 ```bash
 okou generate avatar-video --provider built-in \
@@ -55,15 +66,25 @@ okou generate avatar-video --provider built-in \
   --json < PROJECT/narration.txt
 ```
 
+Voice-only mode, when the selected voice is supported by the built-in voice generator:
+
+```bash
+okou generate voice --provider built-in \
+  --voice VOICE \
+  --json < PROJECT/narration.txt
+```
+
 While that provider job runs, stage the slide assets and prepare the composition manifest. Run these independent branches concurrently when the execution surface permits it.
 
 ### 3. Recover page timings
 
-Download the returned transparent WebM as `assets/presenter.webm` and probe its exact duration. Transcribe it once with `okou video transcribe --file PROJECT/assets/presenter.webm` and align each narration unit to its page. Put a cut at the start of the next unit, or at the midpoint of a real silence gap between units. The first page starts at zero and the final page extends through the exact media duration.
+Download the generated media and probe its exact duration. Use `assets/presenter.webm` in avatar mode and `assets/narration.wav` or the returned audio extension in voice-only mode. Transcribe that media once with `okou video transcribe --file MEDIA` and align each narration unit to its page. Put a cut at the start of the next unit, or at the midpoint of a real silence gap between units. The first page starts at zero and the final page extends through the exact narration duration.
 
 If transcription is unavailable, distribute the measured duration in proportion to spoken word counts, then assign rounding residue to the last page. Do not use the provider's rounded duration when `ffprobe` is available.
 
-### 4. Measure alpha bounds without re-encoding
+### 4. Measure alpha bounds in avatar mode only
+
+Skip this entire step in voice-only mode.
 
 Resolve this skill's mounted directory from the path shown in the available-skills list, then run:
 
@@ -73,7 +94,7 @@ node SKILL_DIR/scripts/probe-alpha-bbox.mjs PROJECT/assets/presenter.webm
 
 Copy its `sourceWidth`, `sourceHeight`, and `bbox` values into the manifest. The composition builder uses CSS clipping and positioning so the visible cutout has the requested width and bottom alignment. Do not crop or transcode the VP9 WebM locally.
 
-Stage only the final presenter WebM and slide images. Do not keep an uncropped duplicate or an unused still inside the cloud-render project.
+In avatar mode, stage only the final presenter WebM and slide images. Do not keep an uncropped duplicate or an unused still inside the cloud-render project. In voice-only mode, stage only the narration audio and slide images.
 
 ### 5. Build the static composition
 
@@ -91,6 +112,7 @@ Create `composition-input.json` in the project using this schema:
     { "path": "assets/slides/page-001.png", "duration": 4.2 },
     { "path": "assets/slides/page-002.png", "duration": 5.1 }
   ],
+  "narration": { "path": "assets/presenter.webm" },
   "presenter": {
     "path": "assets/presenter.webm",
     "sourceWidth": 1920,
@@ -102,13 +124,31 @@ Create `composition-input.json` in the project using this schema:
 }
 ```
 
+For voice-only mode, omit `presenter` entirely:
+
+```json
+{
+  "id": "deck-video",
+  "width": 1920,
+  "height": 1080,
+  "fps": 30,
+  "background": "#000000",
+  "hyperframesVersion": "0.8.26",
+  "slides": [
+    { "path": "assets/slides/page-001.png", "duration": 4.2 },
+    { "path": "assets/slides/page-002.png", "duration": 5.1 }
+  ],
+  "narration": { "path": "assets/narration.wav" }
+}
+```
+
 Use the project-pinned HyperFrames version rather than updating during a job. Then run:
 
 ```bash
 node SKILL_DIR/scripts/build-project.mjs --manifest PROJECT/composition-input.json --out PROJECT
 ```
 
-The builder creates one `data-no-timeline` root composition with static image clips, one persistent transparent video clip, and one audio clip. That marker is the HyperFrames contract for an intentionally static composition; do not add a fake GSAP tween merely to make geometry change. Do not replace the composition with individually authored slide HTML files.
+The builder creates one `data-no-timeline` root composition with static image clips and one narration audio clip. It adds one persistent transparent video clip only in avatar mode. That marker is the HyperFrames contract for an intentionally static composition; do not add a fake GSAP tween merely to make geometry change. Do not replace the composition with individually authored slide HTML files.
 
 ### 6. Run one pre-render gate
 
@@ -124,10 +164,9 @@ Do not run text-layout or contrast audits against bitmap slide contents. Those p
 
 - page count and order;
 - no stretching or unintended cropping;
-- transparent avatar decoding;
-- requested visible width and anchor;
-- captions absent;
-- final slide timing equals presenter duration.
+- avatar mode: transparent avatar decoding, requested visible width and anchor, and captions absent;
+- voice-only mode: no presenter video element or avatar asset;
+- final slide timing equals the narration duration.
 
 ### 7. Render in the cloud once
 
@@ -148,12 +187,12 @@ Use local final rendering only when the user explicitly requests it or cloud acc
 
 ### 8. Final verification and delivery
 
-Run `ffprobe`, a full `ffmpeg` decode, and final ASR comparison concurrently where possible. Confirm resolution, fps, frame count, video duration, audio duration, page order, narration completeness, and presenter placement. For web chat, deliver the verified file with `okou web upload-file -f PROJECT/renders/final.mp4`.
+Run `ffprobe`, a full `ffmpeg` decode, and final ASR comparison concurrently where possible. Confirm resolution, fps, frame count, video duration, audio duration, page order, and narration completeness. Confirm presenter placement only in avatar mode, and confirm presenter absence in voice-only mode. For web chat, deliver the verified file with `okou web upload-file -f PROJECT/renders/final.mp4`.
 
-Report a compact timing table with: deck download, page rasterization, narration preparation, avatar generation, alpha-bound probe, composition build, pre-render QA, cloud package/upload, queue/render, download, final QA, and delivery. Distinguish provider time from agent/tool overhead.
+Report a compact timing table with: deck download, page rasterization, narration preparation, media generation, composition build, pre-render QA, cloud package/upload, queue/render, download, final QA, and delivery. Include alpha-bound probe only in avatar mode. Distinguish provider time from agent/tool overhead.
 
 ## Retry and cost rules
 
 - Use an idempotency key for every cloud render.
-- Retry one transient provider or cloud failure at most once. Do not submit a second billed generation when the first job may still be running.
-- A request to create the final video authorizes the normal avatar-generation and cloud-render charges. Any materially different regeneration needs fresh user direction.
+- Retry one transient provider or cloud failure at most once. Do not submit a second billed media generation when the first job may still be running.
+- A request to create the final video authorizes one media-generation job for the selected mode and the cloud-render charge. Any materially different regeneration needs fresh user direction.

--- a/ppt-avatar-video/scripts/build-project.mjs
+++ b/ppt-avatar-video/scripts/build-project.mjs
@@ -99,59 +99,100 @@ const slides = manifest.slides.map((slide, index) => ({
   }),
 }));
 
-const presenter = manifest.presenter;
-if (!presenter || typeof presenter !== "object") fail("presenter is required");
-
-const presenterPath = validateAsset(presenter.path, "presenter.path");
-const audioPath = validateAsset(
-  presenter.audioPath || presenter.path,
-  "presenter.audioPath",
-);
-const sourceWidth = finiteNumber(
-  presenter.sourceWidth,
-  "presenter.sourceWidth",
-  { min: 1 },
-);
-const sourceHeight = finiteNumber(
-  presenter.sourceHeight,
-  "presenter.sourceHeight",
-  { min: 1 },
-);
-const bbox = presenter.bbox || {};
-const bboxX = finiteNumber(bbox.x, "presenter.bbox.x", { min: 0 });
-const bboxY = finiteNumber(bbox.y, "presenter.bbox.y", { min: 0 });
-const bboxWidth = finiteNumber(bbox.width, "presenter.bbox.width", { min: 1 });
-const bboxHeight = finiteNumber(bbox.height, "presenter.bbox.height", {
-  min: 1,
-});
-if (bboxX + bboxWidth > sourceWidth || bboxY + bboxHeight > sourceHeight) {
-  fail("presenter.bbox exceeds the source video dimensions");
-}
-
-const visibleWidthFraction = finiteNumber(
-  presenter.visibleWidthFraction ?? 0.14,
-  "presenter.visibleWidthFraction",
-  { min: 0.01, max: 1 },
-);
-const anchor = String(presenter.anchor || "bottom-right");
-if (!new Set(["bottom-right", "bottom-left"]).has(anchor)) {
-  fail("presenter.anchor must be bottom-right or bottom-left");
-}
-
 const totalDuration = slides.reduce((sum, slide) => sum + slide.duration, 0);
-const targetVisibleWidth = width * visibleWidthFraction;
-const scale = targetVisibleWidth / bboxWidth;
-const renderedWidth = sourceWidth * scale;
-const renderedHeight = sourceHeight * scale;
-const bottomOffset = -(sourceHeight - bboxY - bboxHeight) * scale;
-const horizontalRule =
-  anchor === "bottom-right"
-    ? `right: ${formatSeconds(-(sourceWidth - bboxX - bboxWidth) * scale)}px;`
-    : `left: ${formatSeconds(-bboxX * scale)}px;`;
-const clipTop = (bboxY / sourceHeight) * 100;
-const clipRight = ((sourceWidth - bboxX - bboxWidth) / sourceWidth) * 100;
-const clipBottom = ((sourceHeight - bboxY - bboxHeight) / sourceHeight) * 100;
-const clipLeft = (bboxX / sourceWidth) * 100;
+
+const presenterInput = manifest.presenter;
+if (
+  presenterInput !== undefined &&
+  presenterInput !== null &&
+  typeof presenterInput !== "object"
+) {
+  fail("presenter must be an object when provided");
+}
+
+let presenter = null;
+if (presenterInput) {
+  const presenterPath = validateAsset(presenterInput.path, "presenter.path");
+  const sourceWidth = finiteNumber(
+    presenterInput.sourceWidth,
+    "presenter.sourceWidth",
+    { min: 1 },
+  );
+  const sourceHeight = finiteNumber(
+    presenterInput.sourceHeight,
+    "presenter.sourceHeight",
+    { min: 1 },
+  );
+  const bbox = presenterInput.bbox || {};
+  const bboxX = finiteNumber(bbox.x, "presenter.bbox.x", { min: 0 });
+  const bboxY = finiteNumber(bbox.y, "presenter.bbox.y", { min: 0 });
+  const bboxWidth = finiteNumber(bbox.width, "presenter.bbox.width", {
+    min: 1,
+  });
+  const bboxHeight = finiteNumber(bbox.height, "presenter.bbox.height", {
+    min: 1,
+  });
+  if (bboxX + bboxWidth > sourceWidth || bboxY + bboxHeight > sourceHeight) {
+    fail("presenter.bbox exceeds the source video dimensions");
+  }
+
+  const visibleWidthFraction = finiteNumber(
+    presenterInput.visibleWidthFraction ?? 0.14,
+    "presenter.visibleWidthFraction",
+    { min: 0.01, max: 1 },
+  );
+  const anchor = String(presenterInput.anchor || "bottom-right");
+  if (!new Set(["bottom-right", "bottom-left"]).has(anchor)) {
+    fail("presenter.anchor must be bottom-right or bottom-left");
+  }
+
+  const targetVisibleWidth = width * visibleWidthFraction;
+  const scale = targetVisibleWidth / bboxWidth;
+  const renderedWidth = sourceWidth * scale;
+  const renderedHeight = sourceHeight * scale;
+  const bottomOffset = -(sourceHeight - bboxY - bboxHeight) * scale;
+  const horizontalRule =
+    anchor === "bottom-right"
+      ? `right: ${formatSeconds(-(sourceWidth - bboxX - bboxWidth) * scale)}px;`
+      : `left: ${formatSeconds(-bboxX * scale)}px;`;
+
+  presenter = {
+    path: presenterPath,
+    anchor,
+    visibleWidthFraction,
+    targetVisibleWidth,
+    scale,
+    renderedWidth,
+    renderedHeight,
+    bottomOffset,
+    horizontalRule,
+    clipTop: (bboxY / sourceHeight) * 100,
+    clipRight: ((sourceWidth - bboxX - bboxWidth) / sourceWidth) * 100,
+    clipBottom: ((sourceHeight - bboxY - bboxHeight) / sourceHeight) * 100,
+    clipLeft: (bboxX / sourceWidth) * 100,
+  };
+}
+
+const narrationInput = manifest.narration;
+if (
+  narrationInput !== undefined &&
+  narrationInput !== null &&
+  typeof narrationInput !== "object"
+) {
+  fail("narration must be an object when provided");
+}
+
+let audioPath;
+if (narrationInput) {
+  audioPath = validateAsset(narrationInput.path, "narration.path");
+} else if (presenterInput) {
+  audioPath = validateAsset(
+    presenterInput.audioPath || presenterInput.path,
+    "presenter.audioPath",
+  );
+} else {
+  fail("narration.path is required when presenter is omitted");
+}
 
 let cursor = 0;
 const slideTags = slides
@@ -161,6 +202,22 @@ const slideTags = slides
     return `      <img id="slide-${String(index + 1).padStart(3, "0")}" class="clip slide" src="${escapeHtml(slide.path)}" alt="Slide ${index + 1}" data-start="${formatSeconds(start)}" data-duration="${formatSeconds(slide.duration)}" />`;
   })
   .join("\n");
+
+const presenterStyle = presenter
+  ? `
+      .presenter-video {
+        z-index: 20;
+        ${presenter.horizontalRule}
+        bottom: ${formatSeconds(presenter.bottomOffset)}px;
+        width: ${formatSeconds(presenter.renderedWidth)}px;
+        height: ${formatSeconds(presenter.renderedHeight)}px;
+        clip-path: inset(${formatSeconds(presenter.clipTop)}% ${formatSeconds(presenter.clipRight)}% ${formatSeconds(presenter.clipBottom)}% ${formatSeconds(presenter.clipLeft)}%);
+        pointer-events: none;
+      }`
+  : "";
+const presenterTag = presenter
+  ? `      <video id="presenter-video" class="clip presenter-video" src="${escapeHtml(presenter.path)}" data-start="0" data-duration="${formatSeconds(totalDuration)}" data-track-index="20" data-layout-allow-overlap data-layout-allow-overflow muted playsinline preload="auto" aria-label="Presenter"></video>\n`
+  : "";
 
 const html = `<!doctype html>
 <html lang="en">
@@ -174,23 +231,14 @@ const html = `<!doctype html>
       #root { position: relative; width: ${width}px; height: ${height}px; overflow: hidden; isolation: isolate; background: ${escapeHtml(background)}; }
       .clip { position: absolute; }
       .slide { inset: 0; z-index: 1; width: ${width}px; height: ${height}px; object-fit: contain; background: ${escapeHtml(background)}; }
-      .presenter-video {
-        z-index: 20;
-        ${horizontalRule}
-        bottom: ${formatSeconds(bottomOffset)}px;
-        width: ${formatSeconds(renderedWidth)}px;
-        height: ${formatSeconds(renderedHeight)}px;
-        clip-path: inset(${formatSeconds(clipTop)}% ${formatSeconds(clipRight)}% ${formatSeconds(clipBottom)}% ${formatSeconds(clipLeft)}%);
-        pointer-events: none;
-      }
-      .presenter-audio { width: 0; height: 0; }
+${presenterStyle}
+      .narration-audio { width: 0; height: 0; }
     </style>
   </head>
   <body>
     <div id="root" data-composition-id="main" data-no-timeline data-start="0" data-duration="${formatSeconds(totalDuration)}" data-width="${width}" data-height="${height}">
 ${slideTags}
-      <video id="presenter-video" class="clip presenter-video" src="${escapeHtml(presenterPath)}" data-start="0" data-duration="${formatSeconds(totalDuration)}" data-track-index="20" data-layout-allow-overlap data-layout-allow-overflow muted playsinline preload="auto" aria-label="Presenter"></video>
-      <audio id="presenter-audio" class="clip presenter-audio" src="${escapeHtml(audioPath)}" data-start="0" data-duration="${formatSeconds(totalDuration)}" data-track-index="30" data-volume="1" preload="auto"></audio>
+${presenterTag}      <audio id="narration-audio" class="clip narration-audio" src="${escapeHtml(audioPath)}" data-start="0" data-duration="${formatSeconds(totalDuration)}" data-track-index="30" data-volume="1" preload="auto"></audio>
     </div>
   </body>
 </html>
@@ -252,14 +300,18 @@ process.stdout.write(
       slides: slides.length,
       duration: totalDuration,
       fps,
-      presenter: {
-        anchor,
-        visibleWidthFraction,
-        targetVisibleWidth,
-        scale,
-        renderedWidth,
-        renderedHeight,
-      },
+      mode: presenter ? "avatar" : "voice-only",
+      narration: { path: audioPath },
+      presenter: presenter
+        ? {
+            anchor: presenter.anchor,
+            visibleWidthFraction: presenter.visibleWidthFraction,
+            targetVisibleWidth: presenter.targetVisibleWidth,
+            scale: presenter.scale,
+            renderedWidth: presenter.renderedWidth,
+            renderedHeight: presenter.renderedHeight,
+          }
+        : null,
     },
     null,
     2,


### PR DESCRIPTION
## Summary

- route static deck-to-video requests between avatar and voice-only modes
- make `presenter` optional and add an explicit `narration.path` manifest input
- skip avatar generation and alpha probing when no avatar was selected
- preserve backward compatibility for existing presenter manifests
- reject silent substitution when a provider-specific voice ID is unavailable for voice-only generation

## Verification

- `npx --yes prettier@3.6.2 --check ppt-avatar-video/SKILL.md ppt-avatar-video/scripts/build-project.mjs`
- `python3 /home/user/.codex/skills/.system/skill-creator/scripts/quick_validate.py ppt-avatar-video`
- `node --check ppt-avatar-video/scripts/build-project.mjs`
- avatar-mode builder smoke test
- voice-only builder smoke test, including assertion that generated HTML has narration audio and no presenter video
- HyperFrames 0.8.26 strict check for avatar mode: 0 errors, 0 warnings
- HyperFrames 0.8.26 strict check for voice-only mode: 0 errors, 0 warnings

## Platform boundary

The built-in voice generator accepts its own TTS voice names, while JoggAI voice IDs are currently exposed only by the avatar-video generator. The skill now reports that mismatch instead of adding a hidden avatar or replacing the selected voice.
