### PR TITLE
fix: honor ppt presenter placement modes

### DIFF
--- a/ppt-avatar-video/SKILL.md
+++ b/ppt-avatar-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ppt-avatar-video
-description: Convert a PPT, PPTX, or PDF directly into a narrated video by preserving each page as a static full-frame slide, with an optional transparent talking avatar. Use for fast deck-to-video requests with voice only or avatar plus voice; do not use for cinematic intros, slide redesign, or tutorial screen recordings.
+description: Convert a PPT, PPTX, or PDF directly into a narrated video by preserving each page as a static slide, with an optional transparent talking avatar in a fixed side layout or adaptive overlay. Use for fast deck-to-video requests with voice only or avatar plus voice; do not use for cinematic intros, slide redesign, or tutorial screen recordings.
 ---
 
 # PPT Narrated Video
@@ -9,7 +9,7 @@ Produce the final video quickly. This is a conversion workflow, not a motion-des
 
 ## Scope boundary
 
-- Preserve every source page as a static full-frame image in the original order.
+- Preserve every source page as a static image in the original order. Voice-only and overlay modes keep the slide full-frame; the two side-by-side modes fit it inside their fixed slide rectangle without cropping.
 - Always include the selected narration. Overlay a transparent talking avatar only when the user selected one.
 - Use hard cuts between pages by default. Add only a short dissolve when the user explicitly requests it.
 - Do not select a design preset, construct an arc, search the HyperFrames catalog, choose blueprints or rules, redesign slides, or author per-slide animation.
@@ -18,11 +18,25 @@ Produce the final video quickly. This is a conversion workflow, not a motion-des
 
 ## Preserve the requested configuration
 
-Use the supplied source, aspect ratio, and voice exactly. Treat avatar configuration as optional: never add or choose an avatar when the user supplied only a voice. When an avatar is supplied, preserve its ID, presenter anchor, and presenter scale exactly. Do not list or search avatars or voices when compatible identifiers are already supplied.
+Use the supplied source, aspect ratio, and voice exactly. Treat avatar configuration as optional: never add or choose an avatar when the user supplied only a voice. When an avatar is supplied, preserve its ID, presenter placement, and presenter scale exactly. Do not list or search avatars or voices when compatible identifiers are already supplied.
 
-For avatar mode, map 16:9 to `landscape`, 9:16 to `portrait`, and 1:1 to `square`. Transparent JoggAI output requires `--screen-style 3 --no-caption`. If placement is absent, use bottom-right. If scale is absent, use a visible presenter width of 14% of the frame. Scale refers to the non-transparent avatar bounds, not the full video canvas. Align the visible avatar's bottom edge with the frame bottom on every page.
+For avatar mode, map 16:9 to `landscape`, 9:16 to `portrait`, and 1:1 to `square`. Transparent JoggAI output requires `--screen-style 3 --no-caption`. If scale is absent, use a visible presenter width of 14% of the frame. Scale refers to the non-transparent avatar bounds, not the full video canvas.
 
 If an exact supplied avatar or voice is rejected, report that blocker. Never silently substitute another identity or voice.
+
+## Select presenter placement
+
+The product exposes exactly three placement choices. Normalize their prompt labels to these manifest values:
+
+- **`left` — presenter on the left, slide on the right.** This is fixed geometry: presenter visible left `3%`; slide left `20%`, top `11.5%`, width `77%`, height `77%`.
+- **`right` — presenter on the right, slide on the left.** This is fixed geometry: slide left `3%`, top `11.5%`, width `77%`, height `77%`; presenter visible right `3%`.
+- **`overlay` — presenter over a full-frame slide.** This is the only adaptive mode. Analyze each slide and place the presenter at the less busy bottom corner.
+
+For both fixed side modes, align the visible presenter's bottom edge with the fixed slide rectangle's bottom edge (`11.5%` above the frame bottom). Do not inspect slide whitespace, choose a corner, or move the presenter between pages in these modes.
+
+For overlay, align the visible presenter with the frame bottom. Treat the product prompt's bottom-right wording as the default and tie-break anchor, not as a reason to skip per-slide blank-space detection. If the user's own editing direction separately requires one fixed overlay corner, honor that explicit override and skip adaptive placement.
+
+When placement is genuinely absent, use `left`, matching the product default. Existing manifests without `presenter.placement` remain valid in the builder and retain their legacy full-frame overlay behavior.
 
 ## Select the media mode
 
@@ -82,7 +96,7 @@ Download the generated media and probe its exact duration. Use `assets/presenter
 
 If transcription is unavailable, distribute the measured duration in proportion to spoken word counts, then assign rounding residue to the last page. Do not use the provider's rounded duration when `ffprobe` is available.
 
-### 4. Measure alpha bounds in avatar mode only
+### 4. Measure avatar and slide geometry only when needed
 
 Skip this entire step in voice-only mode.
 
@@ -94,11 +108,23 @@ node SKILL_DIR/scripts/probe-alpha-bbox.mjs PROJECT/assets/presenter.webm
 
 Copy its `sourceWidth`, `sourceHeight`, and `bbox` values into the manifest. The composition builder uses CSS clipping and positioning so the visible cutout has the requested width and bottom alignment. Do not crop or transcode the VP9 WebM locally.
 
+For `left` and `right`, stop here: their geometry is fixed and must not run a whitespace detector.
+
+For `overlay` only, probe every slide after the presenter bbox is known:
+
+```bash
+node SKILL_DIR/scripts/probe-slide-blank-space.mjs PROJECT/assets/slides \
+  --bbox=BBOX_WIDTHxBBOX_HEIGHT \
+  --visible-width-fraction=0.14
+```
+
+The probe compares visual complexity in the two bottom candidate regions sized to the visible presenter. It chooses `bottom-left` or `bottom-right` per page and keeps the prior side when scores differ by no more than the tie threshold, avoiding needless side-to-side jitter. Copy each returned `presenterAnchor` into the matching slide entry. Do not run the probe for either fixed side mode.
+
 In avatar mode, stage only the final presenter WebM and slide images. Do not keep an uncropped duplicate or an unused still inside the cloud-render project. In voice-only mode, stage only the narration audio and slide images.
 
 ### 5. Build the static composition
 
-Create `composition-input.json` in the project using this schema:
+For a fixed-left layout, create `composition-input.json` using this schema. Use `"placement": "right"` for the mirrored fixed layout; neither mode accepts per-slide anchors.
 
 ```json
 {
@@ -119,7 +145,35 @@ Create `composition-input.json` in the project using this schema:
     "sourceHeight": 1080,
     "bbox": { "x": 618, "y": 184, "width": 596, "height": 874 },
     "visibleWidthFraction": 0.14,
-    "anchor": "bottom-right"
+    "placement": "left"
+  }
+}
+```
+
+For adaptive overlay, keep slides full-frame, set `"placement": "overlay"`, and copy the probe result into each page:
+
+```json
+{
+  "slides": [
+    {
+      "path": "assets/slides/page-001.png",
+      "duration": 4.2,
+      "presenterAnchor": "bottom-right"
+    },
+    {
+      "path": "assets/slides/page-002.png",
+      "duration": 5.1,
+      "presenterAnchor": "bottom-left"
+    }
+  ],
+  "narration": { "path": "assets/presenter.webm" },
+  "presenter": {
+    "path": "assets/presenter.webm",
+    "sourceWidth": 1920,
+    "sourceHeight": 1080,
+    "bbox": { "x": 618, "y": 184, "width": 596, "height": 874 },
+    "visibleWidthFraction": 0.14,
+    "placement": "overlay"
   }
 }
 ```
@@ -148,7 +202,7 @@ Use the project-pinned HyperFrames version rather than updating during a job. Th
 node SKILL_DIR/scripts/build-project.mjs --manifest PROJECT/composition-input.json --out PROJECT
 ```
 
-The builder creates one `data-no-timeline` root composition with static image clips and one narration audio clip. It adds one persistent transparent video clip only in avatar mode. That marker is the HyperFrames contract for an intentionally static composition; do not add a fake GSAP tween merely to make geometry change. Do not replace the composition with individually authored slide HTML files.
+The builder creates one `data-no-timeline` root composition with static image clips and one narration audio clip. It adds one persistent transparent video clip for fixed placement or an overlay that stays on one side. When adaptive overlay changes sides, it creates only the minimum consecutive presenter segments and uses `data-media-start` to keep the take synchronized. That marker is the HyperFrames contract for an intentionally static composition; do not add a fake GSAP tween merely to make geometry change. Do not replace the composition with individually authored slide HTML files.
 
 ### 6. Run one pre-render gate
 
@@ -164,7 +218,9 @@ Do not run text-layout or contrast audits against bitmap slide contents. Those p
 
 - page count and order;
 - no stretching or unintended cropping;
-- avatar mode: transparent avatar decoding, requested visible width and anchor, and captions absent;
+- avatar mode: transparent avatar decoding, requested visible width, placement geometry, and captions absent;
+- fixed `left` or `right`: one presenter segment, the 77% slide rectangle is on the configured side, and no whitespace-probe output appears in the manifest;
+- adaptive `overlay`: slides remain full-frame, every page has a valid probe-derived anchor, and media offsets remain continuous when the side changes;
 - voice-only mode: no presenter video element or avatar asset;
 - final slide timing equals the narration duration.
 

--- a/ppt-avatar-video/scripts/build-project.mjs
+++ b/ppt-avatar-video/scripts/build-project.mjs
@@ -33,6 +33,18 @@ function formatSeconds(value) {
   return Number(value.toFixed(6)).toString();
 }
 
+const PRESENTER_ANCHORS = new Set(["bottom-left", "bottom-right"]);
+const PRESENTER_PLACEMENTS = new Set(["left", "overlay", "right"]);
+
+function optionalPresenterAnchor(value, label) {
+  if (value === undefined || value === null || value === "") return null;
+  const anchor = String(value);
+  if (!PRESENTER_ANCHORS.has(anchor)) {
+    fail(`${label} must be bottom-left or bottom-right`);
+  }
+  return anchor;
+}
+
 const manifestArg = parseFlag("--manifest");
 const outArg = parseFlag("--out");
 if (!manifestArg || !outArg) {
@@ -91,15 +103,26 @@ function validateAsset(relativePath, label) {
   return relativePath.split(path.sep).join("/");
 }
 
-const slides = manifest.slides.map((slide, index) => ({
-  path: validateAsset(slide.path, `slides[${index}].path`),
-  duration: finiteNumber(slide.duration, `slides[${index}].duration`, {
+let slideCursor = 0;
+const slides = manifest.slides.map((slide, index) => {
+  const duration = finiteNumber(slide.duration, `slides[${index}].duration`, {
     min: 0.1,
     max: 3600,
-  }),
-}));
+  });
+  const result = {
+    path: validateAsset(slide.path, `slides[${index}].path`),
+    duration,
+    start: slideCursor,
+    presenterAnchor: optionalPresenterAnchor(
+      slide.presenterAnchor,
+      `slides[${index}].presenterAnchor`,
+    ),
+  };
+  slideCursor += duration;
+  return result;
+});
 
-const totalDuration = slides.reduce((sum, slide) => sum + slide.duration, 0);
+const totalDuration = slideCursor;
 
 const presenterInput = manifest.presenter;
 if (
@@ -141,23 +164,43 @@ if (presenterInput) {
     "presenter.visibleWidthFraction",
     { min: 0.01, max: 1 },
   );
-  const anchor = String(presenterInput.anchor || "bottom-right");
-  if (!new Set(["bottom-right", "bottom-left"]).has(anchor)) {
-    fail("presenter.anchor must be bottom-right or bottom-left");
+  const placement = String(presenterInput.placement || "overlay");
+  if (!PRESENTER_PLACEMENTS.has(placement)) {
+    fail("presenter.placement must be left, overlay, or right");
   }
+  if (
+    placement !== "overlay" &&
+    slides.some((slide) => slide.presenterAnchor)
+  ) {
+    fail("slides[].presenterAnchor is only valid for overlay placement");
+  }
+
+  const requestedAnchor = optionalPresenterAnchor(
+    presenterInput.anchor,
+    "presenter.anchor",
+  );
+  const anchor =
+    placement === "left"
+      ? "bottom-left"
+      : placement === "right"
+        ? "bottom-right"
+        : requestedAnchor || "bottom-right";
+  const horizontalInsetFraction = placement === "overlay" ? 0 : 0.03;
+  const bottomInsetFraction = placement === "overlay" ? 0 : 0.115;
 
   const targetVisibleWidth = width * visibleWidthFraction;
   const scale = targetVisibleWidth / bboxWidth;
   const renderedWidth = sourceWidth * scale;
   const renderedHeight = sourceHeight * scale;
-  const bottomOffset = -(sourceHeight - bboxY - bboxHeight) * scale;
-  const horizontalRule =
-    anchor === "bottom-right"
-      ? `right: ${formatSeconds(-(sourceWidth - bboxX - bboxWidth) * scale)}px;`
-      : `left: ${formatSeconds(-bboxX * scale)}px;`;
+  const bottomOffset =
+    height * bottomInsetFraction - (sourceHeight - bboxY - bboxHeight) * scale;
+  const leftOffset = width * horizontalInsetFraction - bboxX * scale;
+  const rightOffset =
+    width * horizontalInsetFraction - (sourceWidth - bboxX - bboxWidth) * scale;
 
   presenter = {
     path: presenterPath,
+    placement,
     anchor,
     visibleWidthFraction,
     targetVisibleWidth,
@@ -165,7 +208,8 @@ if (presenterInput) {
     renderedWidth,
     renderedHeight,
     bottomOffset,
-    horizontalRule,
+    leftOffset,
+    rightOffset,
     clipTop: (bboxY / sourceHeight) * 100,
     clipRight: ((sourceWidth - bboxX - bboxWidth) / sourceWidth) * 100,
     clipBottom: ((sourceHeight - bboxY - bboxHeight) / sourceHeight) * 100,
@@ -194,29 +238,70 @@ if (narrationInput) {
   fail("narration.path is required when presenter is omitted");
 }
 
-let cursor = 0;
 const slideTags = slides
   .map((slide, index) => {
-    const start = cursor;
-    cursor += slide.duration;
-    return `      <img id="slide-${String(index + 1).padStart(3, "0")}" class="clip slide" src="${escapeHtml(slide.path)}" alt="Slide ${index + 1}" data-start="${formatSeconds(start)}" data-duration="${formatSeconds(slide.duration)}" />`;
+    return `      <img id="slide-${String(index + 1).padStart(3, "0")}" class="clip slide" src="${escapeHtml(slide.path)}" alt="Slide ${index + 1}" data-start="${formatSeconds(slide.start)}" data-duration="${formatSeconds(slide.duration)}" />`;
   })
   .join("\n");
+
+const slideStyle =
+  presenter?.placement === "left"
+    ? `left: 20%; top: 11.5%; width: 77%; height: 77%;`
+    : presenter?.placement === "right"
+      ? `left: 3%; top: 11.5%; width: 77%; height: 77%;`
+      : `inset: 0; width: ${width}px; height: ${height}px;`;
+
+const presenterAnchors = presenter
+  ? slides.map((slide) => {
+      if (presenter.placement === "left") return "bottom-left";
+      if (presenter.placement === "right") return "bottom-right";
+      return slide.presenterAnchor || presenter.anchor;
+    })
+  : [];
+
+const presenterSegments = [];
+for (const [index, slide] of slides.entries()) {
+  if (!presenter) break;
+  const anchor = presenterAnchors[index];
+  const previous = presenterSegments.at(-1);
+  if (previous?.anchor === anchor) {
+    previous.duration += slide.duration;
+  } else {
+    presenterSegments.push({
+      anchor,
+      start: slide.start,
+      duration: slide.duration,
+    });
+  }
+}
 
 const presenterStyle = presenter
   ? `
       .presenter-video {
         z-index: 20;
-        ${presenter.horizontalRule}
         bottom: ${formatSeconds(presenter.bottomOffset)}px;
         width: ${formatSeconds(presenter.renderedWidth)}px;
         height: ${formatSeconds(presenter.renderedHeight)}px;
         clip-path: inset(${formatSeconds(presenter.clipTop)}% ${formatSeconds(presenter.clipRight)}% ${formatSeconds(presenter.clipBottom)}% ${formatSeconds(presenter.clipLeft)}%);
         pointer-events: none;
+      }
+      .presenter-bottom-left {
+        left: ${formatSeconds(presenter.leftOffset)}px;
+      }
+      .presenter-bottom-right {
+        right: ${formatSeconds(presenter.rightOffset)}px;
       }`
   : "";
-const presenterTag = presenter
-  ? `      <video id="presenter-video" class="clip presenter-video" src="${escapeHtml(presenter.path)}" data-start="0" data-duration="${formatSeconds(totalDuration)}" data-track-index="20" data-layout-allow-overlap data-layout-allow-overflow muted playsinline preload="auto" aria-label="Presenter"></video>\n`
+const presenterTags = presenter
+  ? `${presenterSegments
+      .map((segment, index) => {
+        const id =
+          index === 0
+            ? "presenter-video"
+            : `presenter-video-${String(index + 1).padStart(3, "0")}`;
+        return `      <video id="${id}" class="clip presenter-video presenter-${segment.anchor}" src="${escapeHtml(presenter.path)}" data-start="${formatSeconds(segment.start)}" data-duration="${formatSeconds(segment.duration)}" data-media-start="${formatSeconds(segment.start)}" data-track-index="20" data-layout-allow-overlap data-layout-allow-overflow muted playsinline preload="auto" aria-label="Presenter"></video>`;
+      })
+      .join("\n")}\n`
   : "";
 
 const html = `<!doctype html>
@@ -230,7 +315,7 @@ const html = `<!doctype html>
       html, body { margin: 0; width: ${width}px; height: ${height}px; overflow: hidden; background: ${escapeHtml(background)}; }
       #root { position: relative; width: ${width}px; height: ${height}px; overflow: hidden; isolation: isolate; background: ${escapeHtml(background)}; }
       .clip { position: absolute; }
-      .slide { inset: 0; z-index: 1; width: ${width}px; height: ${height}px; object-fit: contain; background: ${escapeHtml(background)}; }
+      .slide { z-index: 1; ${slideStyle} object-fit: contain; background: ${escapeHtml(background)}; }
 ${presenterStyle}
       .narration-audio { width: 0; height: 0; }
     </style>
@@ -238,7 +323,7 @@ ${presenterStyle}
   <body>
     <div id="root" data-composition-id="main" data-no-timeline data-start="0" data-duration="${formatSeconds(totalDuration)}" data-width="${width}" data-height="${height}">
 ${slideTags}
-${presenterTag}      <audio id="narration-audio" class="clip narration-audio" src="${escapeHtml(audioPath)}" data-start="0" data-duration="${formatSeconds(totalDuration)}" data-track-index="30" data-volume="1" preload="auto"></audio>
+${presenterTags}      <audio id="narration-audio" class="clip narration-audio" src="${escapeHtml(audioPath)}" data-start="0" data-duration="${formatSeconds(totalDuration)}" data-track-index="30" data-volume="1" preload="auto"></audio>
     </div>
   </body>
 </html>
@@ -304,7 +389,10 @@ process.stdout.write(
       narration: { path: audioPath },
       presenter: presenter
         ? {
+            placement: presenter.placement,
             anchor: presenter.anchor,
+            slideAnchors: presenterAnchors,
+            segments: presenterSegments,
             visibleWidthFraction: presenter.visibleWidthFraction,
             targetVisibleWidth: presenter.targetVisibleWidth,
             scale: presenter.scale,

--- a/ppt-avatar-video/scripts/probe-slide-blank-space.mjs
+++ b/ppt-avatar-video/scripts/probe-slide-blank-space.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+function fail(message) {
+  process.stderr.write(`probe-slide-blank-space: ${message}\n`);
+  process.exit(1);
+}
+
+function option(name) {
+  const prefix = `--${name}=`;
+  const argument = process.argv
+    .slice(2)
+    .find((value) => value.startsWith(prefix));
+  return argument?.slice(prefix.length);
+}
+
+function numberOption(name, fallback, { min, max }) {
+  const raw = option(name);
+  const value = raw === undefined ? fallback : Number(raw);
+  if (!Number.isFinite(value) || value < min || value > max) {
+    fail(`--${name} must be between ${min} and ${max}`);
+  }
+  return value;
+}
+
+const inputArgs = process.argv
+  .slice(2)
+  .filter((argument) => !argument.startsWith("--"));
+const bboxArg = option("bbox");
+const bboxMatch = bboxArg?.match(/^(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)$/u);
+if (inputArgs.length === 0 || !bboxMatch) {
+  fail(
+    "usage: probe-slide-blank-space.mjs SLIDE_OR_DIR [...] --bbox=WIDTHxHEIGHT [--visible-width-fraction=0.14]",
+  );
+}
+
+const bboxWidth = Number(bboxMatch[1]);
+const bboxHeight = Number(bboxMatch[2]);
+if (bboxWidth <= 0 || bboxHeight <= 0)
+  fail("--bbox dimensions must be positive");
+
+const visibleWidthFraction = numberOption("visible-width-fraction", 0.14, {
+  min: 0.01,
+  max: 0.5,
+});
+const paddingFraction = numberOption("padding-fraction", 0.02, {
+  min: 0,
+  max: 0.2,
+});
+const tieThreshold = numberOption("tie-threshold", 0.08, {
+  min: 0,
+  max: 1,
+});
+const sampleWidth = Math.round(
+  numberOption("sample-width", 480, { min: 64, max: 1920 }),
+);
+const defaultAnchor = option("default-anchor") || "bottom-right";
+if (!new Set(["bottom-left", "bottom-right"]).has(defaultAnchor)) {
+  fail("--default-anchor must be bottom-left or bottom-right");
+}
+
+const imageExtension = /\.(?:jpe?g|png|webp)$/iu;
+const inputPaths = inputArgs.flatMap((input) => {
+  const absolute = path.resolve(input);
+  if (!existsSync(absolute)) fail(`input not found: ${input}`);
+  if (!statSync(absolute).isDirectory()) return [absolute];
+  return readdirSync(absolute)
+    .filter((name) => imageExtension.test(name))
+    .map((name) => path.join(absolute, name));
+});
+
+const slides = [...new Set(inputPaths)]
+  .filter((input) => imageExtension.test(input))
+  .sort((left, right) =>
+    left.localeCompare(right, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    }),
+  );
+if (slides.length === 0) fail("no PNG, JPEG, or WebP slide images found");
+
+function probeDimensions(imagePath) {
+  const probe = spawnSync(
+    "ffprobe",
+    [
+      "-v",
+      "error",
+      "-select_streams",
+      "v:0",
+      "-show_entries",
+      "stream=width,height",
+      "-of",
+      "json",
+      imagePath,
+    ],
+    { encoding: "utf8" },
+  );
+  if (probe.error) fail(`unable to run ffprobe: ${probe.error.message}`);
+  if (probe.status !== 0) {
+    fail(probe.stderr.trim() || `ffprobe failed for ${imagePath}`);
+  }
+  let stream;
+  try {
+    stream = JSON.parse(probe.stdout).streams?.[0];
+  } catch {
+    fail(`ffprobe returned invalid JSON for ${imagePath}`);
+  }
+  if (!stream?.width || !stream?.height) {
+    fail(`image dimensions were not found: ${imagePath}`);
+  }
+  return { width: Number(stream.width), height: Number(stream.height) };
+}
+
+function decodeSample(imagePath, width, height) {
+  const sampleHeight = Math.max(2, Math.round((sampleWidth * height) / width));
+  const decode = spawnSync(
+    "ffmpeg",
+    [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-i",
+      imagePath,
+      "-frames:v",
+      "1",
+      "-vf",
+      `scale=${sampleWidth}:${sampleHeight}:flags=area,format=rgb24`,
+      "-pix_fmt",
+      "rgb24",
+      "-f",
+      "rawvideo",
+      "-",
+    ],
+    { maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (decode.error) fail(`unable to run ffmpeg: ${decode.error.message}`);
+  if (decode.status !== 0) {
+    fail(decode.stderr.toString().trim() || `ffmpeg failed for ${imagePath}`);
+  }
+  const expected = sampleWidth * sampleHeight * 3;
+  if (decode.stdout.length !== expected) {
+    fail(
+      `decoded ${decode.stdout.length} bytes for ${imagePath}; expected ${expected}`,
+    );
+  }
+  return { pixels: decode.stdout, width: sampleWidth, height: sampleHeight };
+}
+
+function regionComplexity(pixels, frameWidth, region) {
+  let edgeCount = 0;
+  let edgeTotal = 0;
+  let strongEdges = 0;
+
+  function colorDifference(first, second) {
+    return (
+      (Math.abs(pixels[first] - pixels[second]) +
+        Math.abs(pixels[first + 1] - pixels[second + 1]) +
+        Math.abs(pixels[first + 2] - pixels[second + 2])) /
+      3
+    );
+  }
+
+  for (let y = region.y; y < region.y + region.height; y += 1) {
+    for (let x = region.x; x < region.x + region.width; x += 1) {
+      const offset = (y * frameWidth + x) * 3;
+      if (x + 1 < region.x + region.width) {
+        const difference = colorDifference(offset, offset + 3);
+        edgeTotal += difference;
+        strongEdges += difference >= 18 ? 1 : 0;
+        edgeCount += 1;
+      }
+      if (y + 1 < region.y + region.height) {
+        const difference = colorDifference(offset, offset + frameWidth * 3);
+        edgeTotal += difference;
+        strongEdges += difference >= 18 ? 1 : 0;
+        edgeCount += 1;
+      }
+    }
+  }
+
+  const meanGradient = edgeCount === 0 ? 0 : edgeTotal / edgeCount / 255;
+  const edgeDensity = edgeCount === 0 ? 0 : strongEdges / edgeCount;
+  return {
+    score: edgeDensity * 0.75 + meanGradient * 0.25,
+    edgeDensity,
+    meanGradient,
+  };
+}
+
+function rounded(value) {
+  return Number(value.toFixed(6));
+}
+
+let previousAnchor = defaultAnchor;
+const results = slides.map((slidePath) => {
+  const dimensions = probeDimensions(slidePath);
+  const sample = decodeSample(slidePath, dimensions.width, dimensions.height);
+  const visibleWidth = sample.width * visibleWidthFraction;
+  const visibleHeight = visibleWidth * (bboxHeight / bboxWidth);
+  const horizontalPadding = sample.width * paddingFraction;
+  const verticalPadding = sample.height * paddingFraction;
+  const regionWidth = Math.min(
+    sample.width,
+    Math.max(2, Math.ceil(visibleWidth + horizontalPadding * 2)),
+  );
+  const regionHeight = Math.min(
+    sample.height,
+    Math.max(2, Math.ceil(visibleHeight + verticalPadding)),
+  );
+  const y = sample.height - regionHeight;
+  const leftRegion = { x: 0, y, width: regionWidth, height: regionHeight };
+  const rightRegion = {
+    x: sample.width - regionWidth,
+    y,
+    width: regionWidth,
+    height: regionHeight,
+  };
+  const left = regionComplexity(sample.pixels, sample.width, leftRegion);
+  const right = regionComplexity(sample.pixels, sample.width, rightRegion);
+  const difference = Math.abs(left.score - right.score);
+  const denominator = Math.max(left.score, right.score, 1e-9);
+  const relativeDifference = difference / denominator;
+  const anchor =
+    relativeDifference <= tieThreshold
+      ? previousAnchor
+      : left.score < right.score
+        ? "bottom-left"
+        : "bottom-right";
+  previousAnchor = anchor;
+
+  return {
+    path: slidePath,
+    presenterAnchor: anchor,
+    scores: {
+      bottomLeft: rounded(left.score),
+      bottomRight: rounded(right.score),
+      relativeDifference: rounded(relativeDifference),
+    },
+  };
+});
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      strategy: "lowest-bottom-corner-complexity",
+      bbox: { width: bboxWidth, height: bboxHeight },
+      visibleWidthFraction,
+      paddingFraction,
+      tieThreshold,
+      defaultAnchor,
+      slides: results,
+    },
+    null,
+    2,
+  )}\n`,
+);


### PR DESCRIPTION
## Summary

- model the product's three presenter placements explicitly: fixed left, fixed right, and adaptive overlay
- keep the two side layouts on their fixed 3% / 20% / 77% / 11.5% geometry without running slide-content analysis
- add a deterministic bottom-corner complexity probe only for full-slide overlay, with stable tie handling and per-page media synchronization
- preserve legacy overlay manifests and the voice-only path merged in #329

## Verification

- `npx --yes prettier@3.6.2 --check ppt-avatar-video/SKILL.md ppt-avatar-video/scripts/build-project.mjs ppt-avatar-video/scripts/probe-slide-blank-space.mjs`
- `node --check` for all three scripts
- skill quick validator passed
- focused builder assertions passed for left, right, adaptive overlay, legacy avatar, and voice-only modes
- synthetic left-busy/right-busy/tie probe cases passed
- real 15-slide deck probe completed in 2.44 seconds and chose the visually empty right corner on all 15 matching pages
- HyperFrames 0.8.26 `lint` and strict `check --samples 5` passed for all five builder modes with 0 errors and 0 warnings
- first/middle/last snapshots confirmed fixed slide geometry and synchronized overlay-side changes
