### PR TITLE
docs(gen): explain byteplus frame and reference input exclusivity

### DIFF
--- a/gen/SKILL.md
+++ b/gen/SKILL.md
@@ -81,6 +81,8 @@ Run `okou generate <type>` with no generation input to list available providers 
 2. Show the actual images through accessible links, briefly describe the intended motion, and ask the user to confirm. End the turn and wait; do not start a video job before confirmation. Revise the preview if requested.
 3. After confirmation, generate the video. Use the approved images as first/last frames or references when supported by the selected model; otherwise follow the approved visual direction in the prompt. Reuse existing confirmation for an unchanged preview.
 
+When using BytePlus/Seedance, choose one supported input mode: first/last frames (`--first-frame-image-url`, `--last-frame-image-url`) or reference media (`--image-url`, `--video-url`, `--audio-url`). Never combine these groups in one request. If the user's requirements need both modes, explain the tradeoff before choosing; do not silently drop supplied inputs. Correct conflicting inputs before retrying.
+
 Keep the preview message short: the images, a brief motion description, and one confirmation question.
 
 ## Asking vs. Choosing


### PR DESCRIPTION
BytePlus rejects requests that combine first/last frames with reference images, videos, or audio. Add guidance to the Gen Skill to choose one supported mode, explain any tradeoff before dropping supplied inputs, and correct conflicting parameters before retrying.

Refs https://github.com/vm0-ai/vm0/issues/32126.
Related server validation and CLI help: https://github.com/vm0-ai/vm0/pull/32313.

Validation: `gen/SKILL.md` passes the repository's frontmatter, required-field, optional-field, and secret-naming rules; `git diff --check` passes. Documentation only; no media generation was run.
