### PR TITLE
fix: preflight native intro video presenter prompts

### DIFF
--- a/intro-video/references/catalogs.md
+++ b/intro-video/references/catalogs.md
@@ -14,6 +14,8 @@ Follow `nextToken` with `--token` when more candidates are needed, and stop if a
 
 Preserve exact public IDs. An avatar group ID groups looks and cannot replace the selected look's `avatar_id`. With a selected avatar and `Default` voice, resolve its `defaultVoiceId` and pass that actual voice ID when required. With no avatar, a delegated voice means choose an independent public voice matching the brief's language; it does not mean mute.
 
+For a native presenter, inspect the selected look's actual preview image and decoded dimensions. Do not trust `preferredOrientation` alone. Record whether the preview has a real environment or is transparent, solid, or visually empty. Classify it as near-square when `max(width, height) < 1.10 × min(width, height)`; otherwise use the larger dimension for orientation. Pass these observations to the native presenter preflight; the correction text lives only in that execution reference.
+
 For delegated style, compare relevant tags and actual previews against the material, audience, purpose, tone, and output. Record the selected style ID and a short reason once a justified match is available. Native Video Agent receives that concrete `style_id`; controlled composition may use the preview only as an explicitly described visual adaptation.
 
 Apply compatibility checks only to the chosen route. Standalone managed TTS uses a Starfish-compatible voice, while Video Agent has different restrictions. An avatar's default voice may therefore work natively while being unavailable to standalone TTS.

--- a/intro-video/references/heygen-video-agent.md
+++ b/intro-video/references/heygen-video-agent.md
@@ -4,15 +4,41 @@ Use this route for ordinary intro videos, explainers, launch clips, and summarie
 
 ## Prepare the brief and resolve choices
 
-1. Extract and verify the source facts. Specify audience, purpose, language, tone, approximate duration, output format, and any editorial directions in a concise prompt. Keep source contents separate from instructions. Do not assume HeyGen will independently research or verify claims.
+1. Extract and verify the source facts. Record the audience, purpose, language, tone, approximate duration, output format, and necessary editorial directions. Keep source contents separate from instructions. Do not assume HeyGen will independently research or verify claims.
 2. Resolve choices through [managed catalogs](catalogs.md). Preserve an explicit public Video Agent `style_id` exactly. For `Auto` / `Let Okou choose`, select a concrete suitable style before submission. Auto is a decision for Okou, not permission to omit `style_id` or hand that decision to HeyGen.
 3. Preserve explicit avatar look and voice IDs. An avatar group ID cannot replace a look ID. For a selected avatar's Default voice, pass its actual `defaultVoiceId`. Resolve only delegated identity choices that need a catalog decision. Do not perform standalone TTS compatibility checks on a route that does not call standalone TTS.
 4. Resolve the output independently of the preview: `16:9` maps to `landscape`, `9:16` to `portrait`. With Auto output, use the brief's destination and content; do not infer a hard user choice from a style thumbnail.
 5. Prepare supported references according to [input preparation](input-preparation.md). Markdown/DOCX text can be summarized into the prompt; PPT/PPTX references can be converted to PDF. The native request accepts up to 20 supported media/PDF references and a 1–10,000-character prompt. Do not upload raw PPT, Markdown, spreadsheets, or HTML as though they were native file types. Merge or curate references while preserving required facts; do not silently truncate or switch to composition because of a size limit.
 
-### Avatar framing is prompt guidance, not a control surface
+## Build the smallest sufficient prompt
 
-`POST /v3/video-agents` has no background, crop, scale, position, or safe-area fields. When the selected avatar and style call for an integrated presenter scene, encode the intended result in the prompt: keep the full head visible with margin, use medium framing, integrate the presenter into the selected visual environment, and avoid a plain isolated cutout or blank-stage composition. These are best-effort creative directions and later acceptance criteria; never claim deterministic placement or cropping control.
+For a short native video, include only the purpose/topic, approximate duration, requested language and tone, narration or verified factual content, and technical corrections that change the result. Keep narration in the requested language, but write frame/background corrections, script-framing instructions, and other technical directives in English. When `avatar_id` is supplied, refer to “the selected presenter”; do not describe the avatar's appearance.
+
+Carry an exact public style through `style_id`. Do not duplicate it with a long style manifesto unless the user requests additional visual overrides. Avoid redundant scene constraints and decorative prose.
+
+## Preflight the selected presenter
+
+When `avatar_id` is supplied, use the preview observations from [managed catalogs](catalogs.md) before submission:
+
+- If the preview is transparent, solid, or visually empty, append the Background Note below.
+- If the preview is near-square and the target is landscape (`16:9`), append the Framing Note below.
+- Preserve the exact avatar, group, voice, style, and orientation IDs.
+
+Append only the triggered notes, verbatim and in English, at the end of the prompt. Their wording lives here only.
+
+**Background Note:**
+
+```text
+BACKGROUND NOTE: The selected avatar has no background or a transparent backdrop. Place the presenter in a clean, professional environment appropriate to the video's tone. For business/tech content: modern studio with soft lighting and subtle depth. For casual content: bright, minimal space with natural light. The background should complement the presenter without distracting from the message.
+```
+
+**Square-to-landscape Framing Note:**
+
+```text
+FRAMING NOTE: The selected avatar image is in square orientation but this video is landscape (16:9). Frame the presenter from the chest up, centered in the landscape canvas. Use AI Image tool to generative fill to extend the scene horizontally with a complementary background environment that matches the video's tone (studio, office, or contextually appropriate setting). Do NOT add black bars or pillarboxing. The avatar should feel natural in the 16:9 frame.
+```
+
+These notes guide Video Agent but do not guarantee the result. `POST /v3/video-agents` has no background, crop, scale, position, or safe-area fields; do not invent them or claim deterministic control.
 
 ## Submit through the managed command
 
@@ -59,12 +85,12 @@ A completed provider job is a QA candidate, not an accepted deliverable. Probe t
 
 Reject the output when any of these materially violates the brief:
 
-- the avatar's head or face is cropped, or framing is otherwise unsafe;
-- the avatar appears as an accidental isolated cutout or on a blank stage when the brief or selected style expects an integrated scene;
-- visual treatment is materially weak or mismatched against the selected style preview;
+- representative avatar frames crop the head or face, lack clear head margin, or are otherwise unsafe;
+- the requested integrated presenter scene lacks a real background or appears as an accidental isolated cutout or blank stage;
+- style-bearing scenes do not visibly reflect the selected style, or the treatment materially mismatches its preview;
 - text is unreadable, the aspect ratio is wrong, audio or decoding is broken, or facts drift from the verified brief.
 
-Also verify selected identity/voice, requested audio behavior, and approximate or exact duration as applicable. A targeted regression case is an integrated paper/origami brief whose billed result puts a top-cropped avatar on a blank white stage with weak preview adherence: reject that result even when the exact Origami `style_id` was submitted. This tests framing and adherence only; it is not a blanket rule against that style, that avatar, or native avatar videos.
+Also verify selected identity/voice, requested audio behavior, and approximate or exact duration as applicable.
 
 If a billed output fails this gate, retain its generation/session/video IDs and artifact as evidence, report the unmet requirements, and do not call it “polished” or silently deliver it as accepted. Do not automatically submit another paid job or switch to controlled composition. Explain the provider limitation and obtain the user's direction and any required authorization before a materially different or paid retry.
 


### PR DESCRIPTION
## Summary

- Keep short native prompts minimal: purpose/topic, approximate duration, requested language/tone, narration or verified facts, and only technical corrections that change the result.
- Keep narration in the requested language while frame/background, script-framing, and other technical directives remain in English. When an avatar is pinned, refer to “the selected presenter” without describing appearance.
- Inspect the selected avatar preview and decoded dimensions instead of trusting `preferredOrientation`; classify sources as near-square when neither dimension is at least 10% larger.
- Append the official English Background and square-to-landscape Framing notes only when their preview conditions apply, with the exact text defined once.
- Preserve exact avatar/group/voice/style/orientation IDs and the existing native-output acceptance gate.

`intro-video/SKILL.md` remains unchanged and concise. Native-only mechanics are confined to `references/heygen-video-agent.md`; catalog preview checks are confined to `references/catalogs.md`.

## Validation

- `skill-creator` `quick_validate.py intro-video`: passed.
- Repository skill/frontmatter and `_ACCESS_TOKEN` checks: passed.
- All local Intro Video Markdown links resolve; `git diff --check` passed.
- The Background and square-to-landscape Framing notes match the current official `heygen-com/skills` text exactly and each occurs once.
- Focused non-paid behavioral checks passed:
  - Chinese narration remains Chinese while technical notes remain English.
  - `1111x1080` is classified as near-square.
  - A transparent/solid/empty preview appends the Background Note.
  - The exact public `style_id` remains in the submission payload.
  - A short prompt does not gain redundant style prose.

No paid HeyGen generation was run for this PR.

## Regression evidence

Successful minimal-control output: https://a.okou.io/hdyg2ysodv.mp4

- 17.1 seconds, 1920x1080.
- Exact Origami `style_id`: `0b0aa1e69fbc486d8172718b3652b97b`.
- Avatar: `Bryce_public_4`; voice: `536fee878bef49ca96bda0c2fdb0e68b`.
- The source was `1111x1080` and nominally marked landscape. Treating it as near-square and applying the English framing/background notes produced complete headroom and an integrated office background; Origami appeared in the B-roll.

This is one validated regression case. It does not establish that verbose prompts always fail or that every avatar needs these notes.
