### PR TITLE
fix: restore official Intro Video prompt literals

### DIFF
--- a/intro-video/references/heygen-video-agent.md
+++ b/intro-video/references/heygen-video-agent.md
@@ -14,6 +14,14 @@ Use this route for ordinary intro videos, explainers, launch clips, and summarie
 
 For a short native video, include only the purpose/topic, approximate duration, requested language and tone, narration or verified factual content, and technical corrections that change the result. Keep narration in the requested language, but write frame/background corrections, script-framing instructions, and other technical directives in English. When `avatar_id` is supplied, refer to “the selected presenter”; do not describe the avatar's appearance.
 
+When narration may be adapted, include this English directive exactly once:
+
+```text
+This script is a concept and theme to convey — not a verbatim transcript. You have full creative freedom to expand, elaborate, add examples, and fill the duration naturally. Do not pad with silence or pauses.
+```
+
+Omit this directive when the user requires verbatim narration; it conflicts with that requirement.
+
 Carry an exact public style through `style_id`. Do not duplicate it with a long style manifesto unless the user requests additional visual overrides. Avoid redundant scene constraints and decorative prose.
 
 ## Preflight the selected presenter
@@ -35,7 +43,7 @@ BACKGROUND NOTE: The selected avatar has no background or a transparent backdrop
 **Square-to-landscape Framing Note:**
 
 ```text
-FRAMING NOTE: The selected avatar image is in square orientation but this video is landscape (16:9). Frame the presenter from the chest up, centered in the landscape canvas. Use AI Image tool to generative fill to extend the scene horizontally with a complementary background environment that matches the video's tone (studio, office, or contextually appropriate setting). Do NOT add black bars or pillarboxing. The avatar should feel natural in the 16:9 frame.
+FRAMING NOTE: The selected avatar image is in square (1:1) orientation but this video is landscape (16:9). Frame the presenter from the chest up, centered in the landscape canvas. Use AI Image tool to generative fill to extend the scene horizontally with a complementary background environment that matches the video's tone (studio, office, or contextually appropriate setting). Do NOT add black bars or pillarboxing. The avatar should feel natural in the 16:9 frame.
 ```
 
 These notes guide Video Agent but do not guarantee the result. `POST /v3/video-agents` has no background, crop, scale, position, or safe-area fields; do not invent them or claim deterministic control.


### PR DESCRIPTION
Fixes https://github.com/vm0-ai/vm0/issues/32377

## Summary

- Repair the post-merge acceptance defect from https://github.com/vm0-ai/vm0-skills/pull/337.
- Restore the official square-to-landscape note with `square (1:1) orientation` verbatim.
- Define the official script-framing directive exactly once, only for adaptable narration, and explicitly omit it for verbatim narration.
- Keep routing, catalogs, QA, and all other files unchanged.

## Validation

- `python3 /home/user/.codex/skills/.system/skill-creator/scripts/quick_validate.py intro-video`
- Repository SKILL.md frontmatter and `_ACCESS_TOKEN` checks
- Intro Video Markdown link check
- Focused non-paid prompt-contract checks for exact literals, single occurrence, adaptable-only inclusion, and verbatim precedence
- Scope assertion confirming only `intro-video/references/heygen-video-agent.md` changed and QA is unchanged
- `git diff --check`

No paid HeyGen generation or production release was performed.
