### PR TITLE
fix(intro-video): teach the agent how to keep the presenter's head in frame

### DIFF
--- a/intro-video/SKILL.md
+++ b/intro-video/SKILL.md
@@ -37,21 +37,24 @@ Only the user's explicit requirements select the route. Filename, MIME type, met
 
 Without the freedom directive, HeyGen pads a short script with silence to reach a stated target; never state a conflicting target duration in verbatim mode.
 
-## Presenter capability check (native route, before any paid submission)
+## Compose the presenter prompt so the head stays in frame
 
-A cropped head is never deliverable. Classify the resolved look with [catalogs](references/catalogs.md): `avatar_type`, whether the preview has a real environment, and its crop risk for the output orientation. Record the classification with the brief.
+HeyGen scales a presenter cutout to fill the frame width and anchors it low, so a near-square look loses the top of its head unless the prompt tells the agent, in the right places, what the presenter scene must look like. Do this for every native submission with a presenter:
 
-1. **Choose the look to avoid cropping.** When Okou chooses, take a `photo_avatar` with a real environment and matching orientation, else a look with `cropRisk: low`. When the user chose a `cropRisk: high` look, say so in the pre-generation sentence, name one low-risk alternative from the same catalog, and keep the user's look unless they switch.
-2. **Compile the complete presenter prompt** from the [prompt compiler](references/prompt-compiler.md): the three presenter sentences, the script-mode directive, the FRAMING NOTE whenever `cropRisk` is high, and the BACKGROUND NOTE for any transparent, solid, or empty preview. A `photo_avatar` with a real environment gets neither note unless its orientation mismatches the output. This complete short prompt is the only configuration that has rendered a full head for a near-square transparent look; never trim it.
-3. **Check the head in every representative frame** at QA. A cropped head or missing headroom rejects the output on both routes. The next attempt changes the look (low-risk or photo avatar) or moves to the controlled route; it never repeats the same prompt and never runs without the user's go-ahead.
+1. **Prefer a look that needs no rescue.** When Okou chooses the look, take one whose preview is at least 1.20 times wider than tall for landscape output (taller than wide for portrait), or a `photo_avatar` with a real environment. Keep an explicitly chosen look, and say in the pre-generation sentence when it is near-square or transparent.
+2. **Open with the brief paragraph and its three presenter sentences**, verbatim from the [prompt compiler](references/prompt-compiler.md): `The selected presenter delivers the narration in a <tone> tone. Use the selected <style name> style. Keep the entire head and hair visible in every presenter shot.` These sentences make the agent plan a presenter scene with an environment instead of pasting the cutout onto the style's stage.
+3. **Put the narration in one quoted `Narration:` paragraph.** Do not split it into scenes or add `Media:` directions; scene-by-scene prompts push the agent into template assembly, which is where the cutout and the cropped head come back.
+4. **Keep the script-mode directive** (freedom, source-only, or verbatim). Removing it to shorten the prompt reverts to the cutout.
+5. **End with the FRAMING NOTE, then the BACKGROUND NOTE**, both verbatim, using the square wording for any look under 1.20; the notes work only together with the sentences and the directive.
+6. **Stay under about 1,500 characters and state one approximate length.** Length caps are ignored; for a hard ceiling set the target well below it.
 
-`scene: integrated` follows the same order: prefer a look with a real environment, otherwise run the complete prompt once, and move to the controlled route only after a failed complete-prompt attempt or on the user's explicit choice.
+Record the look classification (`avatar_type`, environment, crop risk) with the brief and mention that environment and framing are prompt-guided. `scene: integrated` or `framing: safe` in the brief means: pick a look with a real environment when one is available; otherwise run the complete prompt once, and move to the controlled route only after a complete-prompt attempt fails or the user asks for it.
 
 ## Step 4 — Prepare only the selected route, then execute once
 
 Never prepare both routes speculatively. Cache downloads, probes, extractions, conversions, catalog records, and generated assets; do not repeat them during prompt assembly or recovery.
 
-- **Native:** choose the [recipe](references/recipes.md) for the inferred intent, extract and verify facts, prepare only the references the request needs, resolve exact IDs through [catalogs](references/catalogs.md), run the presenter preflight, then compile the prompt once with the [prompt compiler](references/prompt-compiler.md). Submit once, poll the same durable job, and apply the native gate in [QA](references/qa.md).
+- **Native:** choose the [recipe](references/recipes.md) for the inferred intent, extract and verify facts, prepare only the references the request needs, resolve exact IDs through [catalogs](references/catalogs.md), compose the presenter prompt as described above with the [prompt compiler](references/prompt-compiler.md), and submit once. Poll the same durable job, then verify with [QA](references/qa.md).
 - **Controlled:** lock the timeline and preservation plan, then prepare visuals, narration audio, and the HyperFrames project concurrently. A speaking presenter waits only for finalized narration audio. Assemble, validate, render once, then apply the controlled gate.
 
 ## Preserve the user's choices
@@ -66,6 +69,6 @@ Tell the user the route, its consequence, the inferred duration and language, an
 
 ## Accept or reject
 
-A completed provider job is a QA candidate, not a deliverable. Apply [QA](references/qa.md): probe the media, inspect representative frames, transcribe when the brief fixes wording, language, or brand names, and compare against the brief. The gate has two tiers: brief violations are rejected; provider-control gaps are delivered with an explicit warning and evidence, never as polished. In both cases do not automatically submit another paid job, do not repeat the identical prompt, and do not switch routes without the user's direction.
+A completed provider job is a QA candidate, not a deliverable. The prompt is the control and QA is the verification: probe the media, inspect representative frames, transcribe when the brief fixes wording, language, or brand names, and compare against the brief per [QA](references/qa.md). A defect the prompt could have prevented is a prompt error to fix before any retry; a defect that survived a complete prompt is a provider gap to disclose. In both cases do not automatically submit another paid job, do not repeat the identical prompt, and do not switch routes without the user's direction.
 
 Read only the execution reference for the selected route. Consult [provider boundaries](references/provider-boundaries.md) only for a requested capability the selected route does not cover.

--- a/intro-video/references/prompt-compiler.md
+++ b/intro-video/references/prompt-compiler.md
@@ -24,6 +24,13 @@ CRITICAL ON-SCREEN TEXT (display literally):
 <BACKGROUND NOTE, only when triggered>
 ```
 
+## Why the skeleton looks like this
+
+- The agent renders a transparent look by scaling the cutout to fill the frame width and anchoring it low. A near-square look therefore loses the top of its head unless the prompt makes the agent plan a presenter scene: the three presenter sentences do that, and the agent's own plan then starts with generating a background for the presenter.
+- The script-mode directive keeps the agent composing instead of assembling; prompts without it, and long scene-by-scene prompts with `Media:` blocks, revert to the cutout, the cropped head, and invented on-screen details.
+- The FRAMING NOTE and BACKGROUND NOTE describe the correction the agent should make; on their own they are ignored, together with the sentences and the directive they are followed.
+- One narration paragraph, one length, one topic: every extra structure is a chance for the agent to fall back to templates.
+
 ## Slots
 
 1. **Brief paragraph** (English). One format sentence: kind of video, one approximate length, orientation, narration language, audience; in verbatim mode say `The narration length follows the script below.` instead of a length. Then, for a presenter run, the three presenter sentences below in that order; for `presenter: none`, the voice-over-only line. Optionally one placement sentence (`The selected presenter opens and closes on camera.`). Never describe the presenter's appearance.


### PR DESCRIPTION
## Summary

Bingjie's direction: the skill must give the agent enough guidance to avoid cropped heads and blank presenter stages up front, not just gates that catch them after a paid render.

- `SKILL.md`: the presenter section is now prescriptive. Prefer a look that needs no rescue (aspect ≥ 1.20 for the output orientation, or a photo avatar with an environment); open the prompt with the three presenter sentences; keep one quoted `Narration:` paragraph with no per-scene `Media:` blocks; keep the script-mode directive; end with FRAMING then BACKGROUND notes; stay under ~1,500 characters with one approximate length. Records the look classification and frames QA as verification, the prompt as the control.
- `references/prompt-compiler.md`: adds "Why the skeleton looks like this" so the agent understands the mechanism (width-fill scaling of a cutout, the sentences that make the agent plan a presenter scene, the directive that keeps it composing, the notes working only in combination).

## Validation

- Frontmatter validated with the CI rule; `git diff --check` clean; all relative links resolve; fixed literals still live only in `prompt-compiler.md`.
- No paid HeyGen generation was run for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)