### PR TITLE
docs(intro-video): drop the verification date stamps from the references

### DIFF
--- a/intro-video/references/input-preparation.md
+++ b/intro-video/references/input-preparation.md
@@ -1,6 +1,6 @@
 # Input preparation and limits
 
-Verified against the [Video Agent guide](https://developers.heygen.com/docs/video-agent), [uploads](https://developers.heygen.com/docs/upload-assets), [usage limits](https://developers.heygen.com/docs/usage-limits), and [official OpenAPI](https://developers.heygen.com/openapi/external-api.json) on 2026-09-05. Check the endpoint's current schema if a requested option is absent here; general limits pages can be less specific than the endpoint schema.
+Sources: the [Video Agent guide](https://developers.heygen.com/docs/video-agent), [uploads](https://developers.heygen.com/docs/upload-assets), [usage limits](https://developers.heygen.com/docs/usage-limits), and the [official OpenAPI](https://developers.heygen.com/openapi/external-api.json). Check the endpoint's current schema if a requested option is absent here; general limits pages can be less specific than the endpoint schema.
 
 ## Inspect once before routing
 

--- a/intro-video/references/provider-boundaries.md
+++ b/intro-video/references/provider-boundaries.md
@@ -1,6 +1,6 @@
 # Provider capability is not platform capability
 
-Capability reference; execute through the managed commands documented by this skill. The [official HeyGen OpenAPI](https://developers.heygen.com/openapi/external-api.json) and [Video Agent guide](https://developers.heygen.com/docs/video-agent) were checked on 2026-09-07. The default route requires the Okou release containing the managed Video Agent command; the controlled route uses managed speech and transparent-avatar takes. Personal accounts and connector flows remain outside this Intro Video skill.
+Capability reference; execute through the managed commands documented by this skill. Sources: the [official HeyGen OpenAPI](https://developers.heygen.com/openapi/external-api.json) and the [Video Agent guide](https://developers.heygen.com/docs/video-agent). The default route requires the Okou release containing the managed Video Agent command; the controlled route uses managed speech and transparent-avatar takes. Personal accounts and connector flows remain outside this Intro Video skill.
 
 ## Video Agent and public styles
 


### PR DESCRIPTION
## Summary

Bingjie's review, continued: the reference files opened with "verified on <date>" statements. The date of a documentation check is irrelevant to generating a video; the files now name their sources and keep the rule to check the endpoint's current schema. No other content changes.

## Validation

- `git diff --check` clean; all links unchanged; fixed literals untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
